### PR TITLE
Release v0.06.8: PS1+Gaia x-match hardening, fast PS1 mean fetch, Gai…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,30 @@
-# CHANGELOG
+# Changelog
+All notable changes to this project will be documented in this file.
+This project follows Semantic Versioning.
 
-## 0.06.8 (2025-11-02)
-- Robust downloader (SkyView Pixels→Size; STScI DSS fallback) with gzip handling and FITS validation.
-- Two-pass PSF-aware pipeline (SExtractor→PSFEx→SExtractor).
-- Orchestrator writes RUN_COUNTS.json, RUN_INDEX.json, RUN_OVERVIEW.md, RUN_MISSING.json.
-- Exporter writes full **ECSV** and 1‑D subset **CSV** (Parquet optional).
-- `run.sh`: post-run summary, **exit policy**, **--retry-missing**, **--retry-after**.
-- Missing tile list added to overview.
+## [0.06.8] - 2025-11-16
+### Added
+- **PS1 fetch** env knobs: `VASCO_PS1_RADIUS_DEG`, `VASCO_PS1_TIMEOUT`, `VASCO_PS1_ATTEMPTS`, `VASCO_PS1_COLUMNS`.
+- **PS1 disable** toggle via `VASCO_DISABLE_PS1=1` (skips PS1 during dev runs).
+- **Gaia fallback** x-match: if STILTS errors, fall back to Astropy spherical match (2") with numeric coercion.
+
+### Changed
+- **PS1 DR2 mean-table** fetch now requests **explicit columns** (includes `raMean,decMean` + compact mags) for fast, predictable responses.
+- **Auto-detect RA/Dec** in external CSVs (Gaia & PS1) now covers: 
+  `('ra','dec')`, `('RA_ICRS','DE_ICRS')`, `('RAJ2000','DEJ2000')`, `('RA','DEC')`, `('lon','lat')`,
+  and **PS1 mean** `('raMean','decMean')` (TAP alias `('RAMean','DecMean')`).
+- CLI checker `_csv_has_radec()` recognizes **`raMean/decMean`** and **`RAMean/DecMean`** (PS1 x‑match no longer skipped).
+
+### Fixed
+- **Gaia STILTS error** “The name `ra` is unknown.” — robust auto-detection + fallback match.
+- **Gaia unit rows** (e.g., `'deg'`) from VizieR TSV are filtered; fallback coerces to numeric to avoid conversion errors.
+- Restored `retry-missing` command wiring.
+- More robust LDAC→CSV export (Astropy first; STILTS fallback).
+- BOM/whitespace header quirks handled in auto-detection.
+
+### Files touched
+- `vasco/external_fetch_online.py`
+- `vasco/mnras/xmatch_stilts.py`
+- `vasco/cli_pipeline.py`
+
+[0.06.8]: https://github.com/<YOUR-ORG>/<YOUR-REPO>/releases/tag/v0.06.8

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# VASCO v0.06.8 — PS1+Gaia x‑match hardening
+
+**Highlights**
+- Sub‑second PS1 mean-table fetches using explicit columns + small degree radii.
+- Bulletproof Gaia x‑match: STILTS first; if it balks, Astropy fallback finishes the job.
+- PS1 x‑match never skipped: CLI recognizes `raMean/decMean` and `RAMean/DecMean`.
+
+**New env knobs**
+```bash
+# Fast PS1 for dev runs (0.5 arcmin radius)
+export VASCO_PS1_RADIUS_DEG=0.00833333
+export VASCO_PS1_TIMEOUT=12
+export VASCO_PS1_ATTEMPTS=2
+# Optional: disable PS1 entirely while iterating
+# export VASCO_DISABLE_PS1=1

--- a/vasco/cli_pipeline.py
+++ b/vasco/cli_pipeline.py
@@ -1,5 +1,6 @@
+
 from __future__ import annotations
-import argparse, json, time
+import argparse, json, time, subprocess, os
 from pathlib import Path
 from typing import List, Dict, Any
 
@@ -7,6 +8,21 @@ from . import downloader as dl
 from .pipeline import run_psf_two_pass, ToolMissingError
 from .exporter3 import export_and_summarize
 
+# Online external catalog fetchers
+from vasco.external_fetch_online import (
+    fetch_gaia_neighbourhood,
+    fetch_ps1_neighbourhood,
+)
+
+# STILTS helpers
+from vasco.mnras.xmatch_stilts import (
+    xmatch_sextractor_with_gaia,
+    xmatch_sextractor_with_ps1,
+)
+
+# -----------------------------------------------------------
+# Run dirs / overview helpers
+# -----------------------------------------------------------
 
 def _build_run_dir(base: str | Path | None = None) -> Path:
     base = Path(base) if base else Path('data') / 'runs'
@@ -36,7 +52,7 @@ def _expected_stem(ra: float, dec: float, survey: str, size_arcmin: float) -> st
     return f"{tag}_{ra:.6f}_{dec:.6f}_{int(round(size_arcmin))}arcmin"
 
 def _write_overview(run_dir: Path, counts: dict, results: list, missing: list[dict] | None = None) -> None:
-    nl = '\n'
+    nl = ''
     lines = [
         '# Run Overview',
         '',
@@ -58,50 +74,181 @@ def _write_overview(run_dir: Path, counts: dict, results: list, missing: list[di
         lines.append('## Missing tiles (planned but not processed) — first 15')
         for rec in missing[:15]:
             ra = rec.get('ra'); dec = rec.get('dec'); stem = rec.get('expected_stem')
-            lines.append(f"- RA={ra:.6f}  Dec={dec:.6f}  → expected `{stem}`")
+            lines.append(f"- RA={ra:.6f} Dec={dec:.6f} → expected `{stem}`")
         if len(missing) > 15:
             lines.append(f"… and {len(missing)-15} more missing tiles.")
         lines.append('')
     _write_text(run_dir / 'RUN_OVERVIEW.md', nl.join(lines) + nl)
 
+# -----------------------------------------------------------
+# LDAC → CSV export (robust)
+# -----------------------------------------------------------
+
+def _ensure_sextractor_csv(tile_dir: Path, pass2_ldac: str | Path) -> Path:
+    tile_dir = Path(tile_dir)
+    pass2_ldac = Path(pass2_ldac)
+    cat_dir = tile_dir / 'catalogs'
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    sex_csv = cat_dir / 'sextractor_pass2.csv'
+    if sex_csv.exists():
+        return sex_csv
+
+    # Astropy (robust for LDAC)
+    try:
+        from astropy.io import fits
+        import csv as pycsv
+        with fits.open(pass2_ldac, memmap=False) as hdul:
+            hdu = next((h for h in hdul if getattr(h, 'name', '') == 'LDAC_OBJECTS'), None)
+            if hdu is None:
+                hdu = next((h for h in hdul if getattr(h, 'columns', None)), None)
+            if hdu is None:
+                raise RuntimeError('No table HDU with columns found in LDAC')
+            names = [c.name for c in hdu.columns]
+            rows = hdu.data
+        with sex_csv.open('w', newline='') as f:
+            w = pycsv.writer(f)
+            w.writerow(names)
+            for r in rows:
+                w.writerow([r[n] for n in names])
+        return sex_csv
+    except Exception:
+        pass  # STILTS fallback
+
+    try:
+        cmd = ['stilts', 'tcopy', f'in={str(pass2_ldac)}+2', f'out={str(sex_csv)}', 'ofmt=csv']
+        subprocess.run(cmd, check=True)
+        return sex_csv
+    except Exception as e:
+        raise RuntimeError(f'Failed to export LDAC to CSV via Astropy or STILTS: {e}')
+
+# -----------------------------------------------------------
+# CSV header RA/Dec presence check (includes PS1 mean names)
+# -----------------------------------------------------------
+
+def _csv_has_radec(csv_path: Path) -> bool:
+    import csv
+    try:
+        with open(csv_path, newline='') as f:
+            hdr = next(csv.reader(f))
+        cols = {h.strip() for h in hdr}
+        for a, b in [
+            ('ra','dec'), ('RA_ICRS','DE_ICRS'), ('RAJ2000','DEJ2000'),
+            ('RA','DEC'), ('lon','lat'), ('raMean','decMean'), ('RAMean','DecMean')
+        ]:
+            if a in cols and b in cols:
+                return True
+        return False
+    except Exception:
+        return False
+
+# -----------------------------------------------------------
+# Post-xmatch per tile (Gaia/PS1 independent)
+# -----------------------------------------------------------
+
+def _post_xmatch_tile(tile_dir, pass2_ldac, *, radius_arcsec: float = 2.0) -> None:
+    tile_dir = Path(tile_dir)
+    xdir = tile_dir / 'xmatch'
+    xdir.mkdir(parents=True, exist_ok=True)
+
+    sex_csv = _ensure_sextractor_csv(tile_dir, pass2_ldac)
+    gaia_csv = tile_dir / 'catalogs' / 'gaia_neighbourhood.csv'
+    ps1_csv  = tile_dir / 'catalogs' / 'ps1_neighbourhood.csv'
+
+    # Gaia independent
+    try:
+        if gaia_csv.exists() and _csv_has_radec(gaia_csv):
+            out_gaia = xdir / 'sex_gaia_xmatch.csv'
+            xmatch_sextractor_with_gaia(sex_csv, gaia_csv, out_gaia, radius_arcsec=radius_arcsec)
+            print('[POST]', tile_dir.name, 'Gaia xmatch ->', out_gaia)
+        else:
+            print('[POST][WARN]', tile_dir.name, 'Gaia CSV missing or lacks RA/Dec → skipped')
+    except Exception as e:
+        print('[POST][WARN]', tile_dir.name, 'Gaia xmatch failed:', e)
+
+    # PS1 independent
+    try:
+        if ps1_csv.exists() and _csv_has_radec(ps1_csv):
+            out_ps1 = xdir / 'sex_ps1_xmatch.csv'
+            xmatch_sextractor_with_ps1(sex_csv, ps1_csv, out_ps1, radius_arcsec=radius_arcsec)
+            print('[POST]', tile_dir.name, 'PS1  xmatch ->', out_ps1)
+        else:
+            print('[POST][WARN]', tile_dir.name, 'PS1 CSV missing or lacks RA/Dec → skipped')
+    except Exception as e:
+        print('[POST][WARN]', tile_dir.name, 'PS1 xmatch failed:', e)
+
+# -----------------------------------------------------------
+# Commands
+# -----------------------------------------------------------
 
 def cmd_one(args: argparse.Namespace) -> int:
     run_dir = _build_run_dir(Path(args.workdir) if args.workdir else None)
     lg = dl.configure_logger(run_dir / 'logs')
     out_raw = run_dir / 'raw'; out_raw.mkdir(parents=True, exist_ok=True)
+
     fits = dl.fetch_skyview_dss(args.ra, args.dec, size_arcmin=args.size_arcmin,
                                 survey=args.survey, pixel_scale_arcsec=args.pixel_scale_arcsec,
                                 out_dir=out_raw, basename=None, logger=lg)
     td = _tile_dir(run_dir, Path(fits).stem)
+
     try:
         p1, psf, p2 = run_psf_two_pass(fits, td, config_root='configs')
     except ToolMissingError as e:
         print('[ERROR]', e)
         return 2
+
     export_and_summarize(p2, td, export=args.export, histogram_col=args.hist_col)
+
+    # Online external fetch (Gaia via CDS/VizieR, PS1 via MAST)
+    radius_arcmin = args.size_arcmin * (2 ** 0.5) * 0.5
+    try:
+        fetch_gaia_neighbourhood(td, args.ra, args.dec, radius_arcmin)
+    except Exception as e:
+        print('[POST][WARN]', td.name, 'Gaia fetch failed:', e)
+
+    try:
+        if os.getenv('VASCO_DISABLE_PS1'):
+            print('[POST][INFO]', td.name, 'PS1 disabled by env — skipping fetch')
+        else:
+            fetch_ps1_neighbourhood(td, args.ra, args.dec, radius_arcmin)
+    except Exception as e:
+        print('[POST][WARN]', td.name, 'PS1 fetch failed:', e)
+
+    # Post-xmatch (resilient)
+    try:
+        _post_xmatch_tile(td, p2, radius_arcsec=2.0)
+    except Exception as e:
+        print('[POST][WARN] xmatch failed for', td.name, ':', e)
+
     results = [{'tile': Path(fits).stem, 'pass1': p1, 'psf': psf, 'pass2': p2}]
     counts = {'planned': 1, 'downloaded': 1, 'processed': 1}
     missing: list[dict] = []
+
     _write_json(run_dir / 'RUN_INDEX.json', results)
     _write_json(run_dir / 'RUN_COUNTS.json', counts)
     _write_json(run_dir / 'RUN_MISSING.json', missing)
     _write_overview(run_dir, counts, results, missing)
+
     print('Run directory:', run_dir)
     print('Planned tiles:', counts['planned'], 'Downloaded:', counts['downloaded'], 'Processed:', counts['processed'])
     return 0
+
 
 def cmd_tess(args: argparse.Namespace) -> int:
     run_dir = _build_run_dir(Path(args.workdir) if args.workdir else None)
     lg = dl.configure_logger(run_dir / 'logs')
     out_raw = run_dir / 'raw'; out_raw.mkdir(parents=True, exist_ok=True)
+
     centers = dl.tessellate_centers(args.center_ra, args.center_dec,
                                     width_arcmin=args.width_arcmin, height_arcmin=args.height_arcmin,
                                     tile_radius_arcmin=args.tile_radius_arcmin, overlap_arcmin=args.overlap_arcmin)
     planned = len(centers)
+
     fits_list = dl.fetch_many(centers, size_arcmin=args.size_arcmin, survey=args.survey,
                               pixel_scale_arcsec=args.pixel_scale_arcsec, out_dir=out_raw, logger=lg)
     downloaded = len(fits_list)
+
     results: list[Dict[str, Any]] = []
+
     for fp in fits_list:
         stem = Path(fp).stem
         td = _tile_dir(run_dir, stem)
@@ -110,11 +257,40 @@ def cmd_tess(args: argparse.Namespace) -> int:
         except ToolMissingError as e:
             print('[ERROR]', e)
             continue
-        export_and_summarize(p2, td, export=args.export, histogram_col=args.hist_col)
-        results.append({'tile': stem, 'pass1': p1, 'psf': psf, 'pass2': p2})
-    processed = len(results)
 
+        export_and_summarize(p2, td, export=args.export, histogram_col=args.hist_col)
+
+        # Online external fetch per tile
+        radius_arcmin = args.size_arcmin * (2 ** 0.5) * 0.5
+        try:
+            parts = stem.split('_')
+            ra_t = float(parts[1]); dec_t = float(parts[2])
+        except Exception:
+            ra_t, dec_t = centers[0]
+
+        try:
+            fetch_gaia_neighbourhood(td, ra_t, dec_t, radius_arcmin)
+        except Exception as e:
+            print('[POST][WARN]', td.name, 'Gaia fetch failed:', e)
+
+        try:
+            if os.getenv('VASCO_DISABLE_PS1'):
+                print('[POST][INFO]', td.name, 'PS1 disabled by env — skipping fetch')
+            else:
+                fetch_ps1_neighbourhood(td, ra_t, dec_t, radius_arcmin)
+        except Exception as e:
+            print('[POST][WARN]', td.name, 'PS1 fetch failed:', e)
+
+        try:
+            _post_xmatch_tile(td, p2, radius_arcsec=2.0)
+        except Exception as e:
+            print('[POST][WARN] xmatch failed for', td.name, ':', e)
+
+        results.append({'tile': stem, 'pass1': p1, 'psf': psf, 'pass2': p2})
+
+    processed = len(results)
     processed_stems = {rec['tile'] for rec in results}
+
     missing: list[dict] = []
     for ra, dec in centers:
         exp_stem = _expected_stem(ra, dec, args.survey, args.size_arcmin)
@@ -122,6 +298,7 @@ def cmd_tess(args: argparse.Namespace) -> int:
             missing.append({'ra': float(ra), 'dec': float(dec), 'expected_stem': exp_stem})
 
     counts = {'planned': planned, 'downloaded': downloaded, 'processed': processed}
+
     _write_json(run_dir / 'RUN_INDEX.json', results)
     _write_json(run_dir / 'RUN_COUNTS.json', counts)
     _write_json(run_dir / 'RUN_MISSING.json', missing)
@@ -133,7 +310,9 @@ def cmd_tess(args: argparse.Namespace) -> int:
         print(f"Missing tiles: {len(missing)} (see RUN_MISSING.json / RUN_OVERVIEW.md)")
     return 0
 
-# retry missing
+# -----------------------------------------------------------
+# retry-missing
+# -----------------------------------------------------------
 
 def _retry_sleep(attempt: int, base: float, cap: float) -> None:
     import random, time as _t
@@ -146,24 +325,30 @@ def cmd_retry_missing(args: argparse.Namespace) -> int:
     if not run_dir.exists():
         print('[ERROR] run dir not found:', run_dir)
         return 2
-    counts_path = run_dir / 'RUN_COUNTS.json'
+
+    counts_path  = run_dir / 'RUN_COUNTS.json'
     missing_path = run_dir / 'RUN_MISSING.json'
-    index_path = run_dir / 'RUN_INDEX.json'
+    index_path   = run_dir / 'RUN_INDEX.json'
+
     if not missing_path.exists():
         print('[INFO] No RUN_MISSING.json found. Nothing to retry.')
         print('Run directory:', run_dir)
         return 0
+
     try:
-        counts = _read_json(counts_path) if counts_path.exists() else {'planned':0,'downloaded':0,'processed':0}
+        counts  = _read_json(counts_path)  if counts_path.exists() else {'planned':0,'downloaded':0,'processed':0}
         missing = _read_json(missing_path)
-        results = _read_json(index_path) if index_path.exists() else []
+        results = _read_json(index_path)   if index_path.exists()  else []
     except Exception as e:
         print('[ERROR] cannot read run artifacts:', e)
         return 2
+
     lg = dl.configure_logger(run_dir / 'logs')
     out_raw = run_dir / 'raw'; out_raw.mkdir(parents=True, exist_ok=True)
+
     recovered: list[dict] = []
     still_missing: list[dict] = []
+
     for rec in missing:
         ra = float(rec['ra']); dec = float(rec['dec'])
         ok = False; fp = None
@@ -174,39 +359,71 @@ def cmd_retry_missing(args: argparse.Namespace) -> int:
                 ok = True; break
             except Exception as e:
                 print(f"[WARN] Retry {attempt}/{args.attempts} failed for RA={ra:.6f} Dec={dec:.6f}: {e}")
-                if attempt < args.attempts:
-                    _retry_sleep(attempt, args.backoff_base, args.backoff_cap)
+            if attempt < args.attempts:
+                _retry_sleep(attempt, args.backoff_base, args.backoff_cap)
         if not ok or fp is None:
             still_missing.append(rec); continue
+
         stem = Path(fp).stem
         td = _tile_dir(run_dir, stem)
         try:
             p1, psf, p2 = run_psf_two_pass(fp, td, config_root='configs')
             export_and_summarize(p2, td, export=args.export, histogram_col=args.hist_col)
+
+            # Online fetch + post-xmatch
+            radius_arcmin = args.size_arcmin * (2 ** 0.5) * 0.5
+            try:
+                parts = stem.split('_')
+                ra_t = float(parts[1]); dec_t = float(parts[2])
+            except Exception:
+                ra_t, dec_t = ra, dec
+
+            try:
+                fetch_gaia_neighbourhood(td, ra_t, dec_t, radius_arcmin)
+            except Exception as e:
+                print('[POST][WARN]', td.name, 'Gaia fetch failed:', e)
+            try:
+                if os.getenv('VASCO_DISABLE_PS1'):
+                    print('[POST][INFO]', td.name, 'PS1 disabled by env — skipping fetch')
+                else:
+                    fetch_ps1_neighbourhood(td, ra_t, dec_t, radius_arcmin)
+            except Exception as e:
+                print('[POST][WARN]', td.name, 'PS1 fetch failed:', e)
+            try:
+                _post_xmatch_tile(td, p2, radius_arcsec=2.0)
+            except Exception as e:
+                print('[POST][WARN] xmatch failed for', td.name, ':', e)
+
             results.append({'tile': stem, 'pass1': p1, 'psf': psf, 'pass2': p2})
             recovered.append({'ra': ra, 'dec': dec, 'expected_stem': stem})
         except ToolMissingError as e:
             print('[ERROR] Tools missing for', stem, ':', e); still_missing.append(rec)
         except Exception as e:
             print('[ERROR] Processing failed for', stem, ':', e); still_missing.append(rec)
-    prev_processed = int(counts.get('processed', 0) or 0)
+
+    prev_processed  = int(counts.get('processed',  0) or 0)
     prev_downloaded = int(counts.get('downloaded', 0) or 0)
-    counts['processed'] = prev_processed + len(recovered)
+    counts['processed']  = prev_processed  + len(recovered)
     counts['downloaded'] = prev_downloaded + len(recovered)
+
     _write_json(index_path, results)
     _write_json(counts_path, counts)
     _write_json(missing_path, still_missing)
     _write_overview(run_dir, counts, results, still_missing)
+
     print('Run directory:', run_dir)
-    print(f"Recovered tiles: {len(recovered)}  Remaining missing: {len(still_missing)}")
+    print(f"Recovered tiles: {len(recovered)} Remaining missing: {len(still_missing)}")
     return 0
 
+# -----------------------------------------------------------
+# CLI
+# -----------------------------------------------------------
 
 def main(argv: List[str] | None = None) -> int:
-    p = argparse.ArgumentParser(prog='vasco.cli_pipeline', description='VASCO pipeline orchestrator (download + 2-pass + export + QA)')
+    p = argparse.ArgumentParser(prog='vasco.cli_pipeline', description='VASCO pipeline orchestrator (download + 2-pass + export + QA + post-xmatch)')
     sub = p.add_subparsers(dest='cmd')
 
-    one = sub.add_parser('one2pass', help='One RA/Dec -> download -> two-pass pipeline')
+    one = sub.add_parser('one2pass', help='One RA/Dec -> download -> two-pass pipeline (auto fetch + post-xmatch)')
     one.add_argument('--ra', type=float, required=True)
     one.add_argument('--dec', type=float, required=True)
     one.add_argument('--size-arcmin', type=float, default=60.0)
@@ -217,7 +434,7 @@ def main(argv: List[str] | None = None) -> int:
     one.add_argument('--workdir', default=None)
     one.set_defaults(func=cmd_one)
 
-    tess = sub.add_parser('tess2pass', help='Tessellate region and run two-pass pipeline per tile')
+    tess = sub.add_parser('tess2pass', help='Tessellate region and run two-pass pipeline per tile (auto fetch + post-xmatch)')
     tess.add_argument('--center-ra', type=float, required=True)
     tess.add_argument('--center-dec', type=float, required=True)
     tess.add_argument('--width-arcmin', type=float, required=True)
@@ -232,7 +449,7 @@ def main(argv: List[str] | None = None) -> int:
     tess.add_argument('--workdir', default=None)
     tess.set_defaults(func=cmd_tess)
 
-    rt = sub.add_parser('retry-missing', help='Retry tiles listed in RUN_MISSING.json for a prior run directory')
+    rt = sub.add_parser('retry-missing', help='Retry tiles for an existing run (auto fetch + post-xmatch)')
     rt.add_argument('run_dir', help='Existing run directory (data/runs/run-YYYYMMDD_HHMMSS)')
     rt.add_argument('--survey', default='dss1-red')
     rt.add_argument('--size-arcmin', type=float, default=60.0)

--- a/vasco/external_fetch_online.py
+++ b/vasco/external_fetch_online.py
@@ -1,0 +1,143 @@
+
+from __future__ import annotations
+from pathlib import Path
+import csv
+import requests
+
+__all__ = [
+    'fetch_gaia_neighbourhood',
+    'fetch_ps1_neighbourhood',
+]
+
+# ---------------------------------------------------------------
+# Gaia DR3 via CDS/VizieR (normalize to ra/dec; skip unit rows)
+# ---------------------------------------------------------------
+_VIZIER_TSV = 'https://vizier.u-strasbg.fr/viz-bin/asu-tsv'
+_DEF_GAIA_COLS = [
+    'RA_ICRS', 'DE_ICRS', 'Gmag', 'BPmag', 'RPmag', 'pmRA', 'pmDE', 'Plx', '_r'
+]
+
+def fetch_gaia_neighbourhood(tile_dir: Path | str,
+                             ra_deg: float, dec_deg: float,
+                             radius_arcmin: float,
+                             *, max_rows: int = 200000,
+                             timeout: float = 60.0) -> Path:
+    """Fetch Gaia DR3 neighborhood via VizieR TSV -> CSV; map RA/Dec and filter unit rows."""
+    tile_dir = Path(tile_dir)
+    out = tile_dir / 'catalogs' / 'gaia_neighbourhood.csv'
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    params = {
+        '-source': 'I/355/gaiadr3',
+        '-c': f'{ra_deg} {dec_deg}',
+        '-c.r': f'{radius_arcmin:.6f}',
+        '-out.max': str(max_rows),
+        '-out.add': '_r',
+        '-out.form': 'dec',
+        '-sort': '_r',
+        '-out': ','.join(_DEF_GAIA_COLS),
+    }
+    r = requests.get(_VIZIER_TSV, params=params, timeout=timeout)
+    r.raise_for_status()
+
+    # Keep non-empty, non-comment lines
+    lines = [row for row in r.text.splitlines() if row and not row.startswith('#')]
+    if not lines:
+        out.write_text('ra,dec')
+        return out
+
+    header = lines[0].split('	')
+    data_rows = [ln.split('	') for ln in lines[1:]]
+    colmap = {name: idx for idx, name in enumerate(header)}
+    keep = [c for c in _DEF_GAIA_COLS if c in colmap]
+
+    with out.open('w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['ra' if c=='RA_ICRS' else ('dec' if c=='DE_ICRS' else c) for c in keep])
+        for row in data_rows:
+            try:
+                # Ensure RA/DEC are numeric (skip unit rows like 'deg')
+                float(row[colmap['RA_ICRS']]); float(row[colmap['DE_ICRS']])
+            except Exception:
+                continue
+            w.writerow([row[colmap[c]] for c in keep])
+    return out
+
+# ---------------------------------------------------------------
+# PS1 DR2 via MAST Catalogs API (mean table, explicit columns)
+# ---------------------------------------------------------------
+
+def fetch_ps1_neighbourhood(tile_dir: Path | str,
+                             ra_deg: float, dec_deg: float,
+                             radius_arcmin: float,
+                             *, max_records: int = 50000,
+                             timeout: float = 60.0) -> Path:
+    """Fetch PS1 DR2 mean-table neighborhood CSV with explicit columns and progress logs.
+
+    Honors environment variables:
+        VASCO_PS1_RADIUS_DEG  (override radius in degrees)
+        VASCO_PS1_TIMEOUT     (seconds per attempt)
+        VASCO_PS1_ATTEMPTS    (retry attempts)
+        VASCO_PS1_COLUMNS     (comma-separated override of requested columns)
+    """
+    import os, time
+
+    tile_dir = Path(tile_dir)
+    out = tile_dir / 'catalogs' / 'ps1_neighbourhood.csv'
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    # Radius (degrees). Cap to 0.5 deg; allow override for dev/testing.
+    radius_deg = None
+    _r = os.getenv('VASCO_PS1_RADIUS_DEG')
+    if _r:
+        try:
+            radius_deg = float(_r)
+        except Exception:
+            radius_deg = None
+    if radius_deg is None:
+        radius_deg = min(float(radius_arcmin) / 60.0, 0.5)
+
+    base = 'https://catalogs.mast.stsci.edu/api/v0.1/panstarrs'
+    url  = base + '/dr2/mean.csv'
+
+    _timeout  = float(os.getenv('VASCO_PS1_TIMEOUT', timeout))
+    _attempts = int(os.getenv('VASCO_PS1_ATTEMPTS', '3'))
+
+    default_cols = [
+        'objID','raMean','decMean','nDetections','ng','nr','ni','nz','ny',
+        'gMeanPSFMag','rMeanPSFMag','iMeanPSFMag','zMeanPSFMag','yMeanPSFMag'
+    ]
+    _cols_override = os.getenv('VASCO_PS1_COLUMNS')
+    cols = [c.strip() for c in _cols_override.split(',')] if _cols_override else default_cols
+
+    params = {
+        'ra': '{:.8f}'.format(float(ra_deg)),
+        'dec': '{:.8f}'.format(float(dec_deg)),
+        'radius': '{:.8f}'.format(float(radius_deg)),
+        'nDetections.gte': '1',
+        'pagesize': str(int(max_records)),
+        'format': 'csv',
+        'columns': '[' + ','.join(cols) + ']'
+    }
+
+    def _try_once():
+        t0 = time.time()
+        print('[POST][PS1] GET {} (timeout={}s, radius={})'.format(url, _timeout, params['radius']))
+        r = requests.get(url, params=params, timeout=_timeout)
+        r.raise_for_status()
+        dt = time.time() - t0
+        print('[POST][PS1] OK in {:.2f}s ({} bytes)'.format(dt, len(r.content)))
+        return r
+
+    last_exc = None
+    for k in range(1, _attempts + 1):
+        try:
+            r = _try_once()
+            out.write_bytes(r.content)
+            return out
+        except Exception as e:
+            last_exc = e
+            print('[POST][WARN] PS1 attempt {}/{} failed: {}'.format(k, _attempts, e))
+            if k < _attempts:
+                time.sleep(min(10, 1.5 ** k))
+    raise last_exc

--- a/vasco/mnras/xmatch_stilts.py
+++ b/vasco/mnras/xmatch_stilts.py
@@ -1,0 +1,194 @@
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Tuple, Iterable
+import csv
+
+from vasco.utils.stilts_wrapper import stilts_xmatch
+
+# ---------------------------------------------------------------------
+# Generic RA/Dec detector for any CSV table (external catalogs)
+# ---------------------------------------------------------------------
+
+def _guess_radec_any(csv_path, preference=("ra","dec")) -> Tuple[str, str]:
+    import csv as _csv
+    from pathlib import Path as _Path
+    cand = [
+        preference,
+        ("RA_ICRS","DE_ICRS"), ("RAJ2000","DEJ2000"),
+        ("RA","DEC"), ("lon","lat"), ("ra","dec"),
+        # PS1 mean / TAP variants
+        ("raMean","decMean"), ("RAMean","DecMean"),
+    ]
+    with _Path(csv_path).open(newline='') as f:
+        r = _csv.reader(f); hdr = next(r)
+    cols = set(h.strip().lstrip('﻿') for h in hdr)
+    for ra, dec in cand:
+        if ra in cols and dec in cols:
+            return ra, dec
+    raise ValueError(f'RA/Dec not found in {csv_path}; header={hdr[:12]}')
+
+# SExtractor candidates
+_SEX_CANDIDATES: Iterable[Tuple[str,str]] = (
+    ("ALPHA_J2000", "DELTA_J2000"),
+    ("ALPHAWIN_J2000", "DELTAWIN_J2000"),
+    ("X_WORLD", "Y_WORLD"),
+    ("ra", "dec"),
+    ("RA", "DEC"),
+    ("RAJ2000", "DEJ2000"),
+)
+
+def _guess_sextractor_radec(csv_path: Path | str) -> Tuple[str,str]:
+    p = Path(csv_path)
+    with p.open(newline='') as f:
+        r = csv.reader(f)
+        try:
+            header = next(r)
+        except StopIteration:
+            raise ValueError(f"Empty CSV: {p}")
+    header = [h.strip().lstrip('﻿') for h in header]
+    cols = set(header)
+    for ra_col, dec_col in _SEX_CANDIDATES:
+        if ra_col in cols and dec_col in cols:
+            return ra_col, dec_col
+    raise ValueError(
+        f"Could not find RA/Dec columns in {p}. Tried: " +
+        ", ".join(f"({a},{b})" for a,b in _SEX_CANDIDATES)
+    )
+
+# Wrapper around STILTS call
+
+def xmatch_catalogs_stilts(
+    table1: Path | str,
+    table2: Path | str,
+    out_table: Path | str,
+    *,
+    ra1: str, dec1: str,
+    ra2: str, dec2: str,
+    radius_arcsec: float = 2.0,
+    join_type: str = '1and2',
+    ofmt: Optional[str] = None,
+    find: Optional[str] = None,
+) -> Path:
+    t1 = str(table1); t2 = str(table2); out = str(out_table)
+    stilts_xmatch(
+        t1, t2, out,
+        ra1=ra1, dec1=dec1,
+        ra2=ra2, dec2=dec2,
+        radius_arcsec=radius_arcsec,
+        join_type=join_type,
+        ofmt=ofmt,
+        find=find,
+    )
+    return Path(out)
+
+# Gaia fallback (Astropy) with numeric coercion
+
+def _gaia_fallback_match(sex_catalog_csv: Path | str,
+                         gaia_catalog_csv: Path | str,
+                         out_csv: Path | str,
+                         *,
+                         radius_arcsec: float) -> Path:
+    import pandas as pd
+    from astropy.coordinates import SkyCoord
+    import astropy.units as u
+
+    sex_p = Path(sex_catalog_csv)
+    gaia_p = Path(gaia_catalog_csv)
+    out_p = Path(out_csv)
+    out_p.parent.mkdir(parents=True, exist_ok=True)
+
+    df1 = pd.read_csv(sex_p)
+    df2 = pd.read_csv(gaia_p)
+
+    # SExtractor columns (preference order)
+    pref1 = [
+        ('ALPHAWIN_J2000','DELTAWIN_J2000'),
+        ('ALPHA_J2000','DELTA_J2000'),
+        ('X_WORLD','Y_WORLD'),
+        ('ra','dec'), ('RA','DEC'), ('RAJ2000','DEJ2000')
+    ]
+    for a,b in pref1:
+        if a in df1.columns and b in df1.columns:
+            ra1, dec1 = a, b
+            break
+    else:
+        raise RuntimeError('Fallback: cannot find RA/Dec in SExtractor CSV')
+
+    # Gaia columns (normalized to ra/dec by our fetcher; accept variants)
+    pref2 = [('ra','dec'), ('RA_ICRS','DE_ICRS'), ('RAJ2000','DEJ2000'), ('RA','DEC')]
+    for a,b in pref2:
+        if a in df2.columns and b in df2.columns:
+            ra2, dec2 = a, b
+            break
+    else:
+        raise RuntimeError('Fallback: cannot find RA/Dec in Gaia CSV')
+
+    # Coerce to numeric (drop any non-numeric rows)
+    import pandas as pd
+    df1['_ra']  = pd.to_numeric(df1[ra1], errors='coerce')
+    df1['_dec'] = pd.to_numeric(df1[dec1], errors='coerce')
+    df2['_ra']  = pd.to_numeric(df2[ra2], errors='coerce')
+    df2['_dec'] = pd.to_numeric(df2[dec2], errors='coerce')
+    df1v = df1.dropna(subset=['_ra','_dec']).reset_index(drop=True)
+    df2v = df2.dropna(subset=['_ra','_dec']).reset_index(drop=True)
+
+    c1 = SkyCoord(df1v['_ra'].to_numpy()*u.deg, df1v['_dec'].to_numpy()*u.deg)
+    c2 = SkyCoord(df2v['_ra'].to_numpy()*u.deg, df2v['_dec'].to_numpy()*u.deg)
+
+    idx1, idx2, sep2d, _ = c2.search_around_sky(c1, radius_arcsec*u.arcsec)
+    matched = (df1v.iloc[idx2].reset_index(drop=True)
+               .join(df2v.iloc[idx1].reset_index(drop=True), lsuffix='_sex', rsuffix='_gaia'))
+    matched['sep_arcsec'] = sep2d.arcsec
+    matched.to_csv(out_p, index=False)
+    return out_p
+
+
+def xmatch_sextractor_with_gaia(
+    sex_catalog_csv: Path | str,
+    gaia_catalog_csv: Path | str,
+    out_csv: Path | str,
+    *,
+    radius_arcsec: float = 2.0,
+    join_type: str = '1and2',
+) -> Path:
+    ra1, dec1 = _guess_sextractor_radec(sex_catalog_csv)
+    try:
+        ra2, dec2 = _guess_radec_any(gaia_catalog_csv, preference=("ra","dec"))
+    except Exception:
+        ra2, dec2 = ("ra","dec")
+
+    # Try STILTS first
+    try:
+        return xmatch_catalogs_stilts(
+            sex_catalog_csv, gaia_catalog_csv, out_csv,
+            ra1=ra1, dec1=dec1,
+            ra2=ra2, dec2=dec2,
+            radius_arcsec=radius_arcsec,
+            join_type=join_type,
+            ofmt='csv',
+        )
+    except Exception as e:
+        print('[POST][INFO] Gaia STILTS failed (', e, ') — using Astropy fallback')
+        return _gaia_fallback_match(sex_catalog_csv, gaia_catalog_csv, out_csv,
+                                    radius_arcsec=radius_arcsec)
+
+
+def xmatch_sextractor_with_ps1(
+    sex_catalog_csv: Path | str,
+    ps1_catalog_csv: Path | str,
+    out_csv: Path | str,
+    *,
+    radius_arcsec: float = 2.0,
+    join_type: str = '1and2',
+) -> Path:
+    ra1, dec1 = _guess_sextractor_radec(sex_catalog_csv)
+    ra2, dec2 = _guess_radec_any(ps1_catalog_csv, preference=("ra","dec"))
+    return xmatch_catalogs_stilts(
+        sex_catalog_csv, ps1_catalog_csv, out_csv,
+        ra1=ra1, dec1=dec1,
+        ra2=ra2, dec2=dec2,
+        radius_arcsec=radius_arcsec,
+        join_type=join_type,
+        ofmt='csv',
+    )


### PR DESCRIPTION

**Highlights**
- Sub‑second PS1 mean-table fetches using explicit columns + small degree radii.
- Bulletproof Gaia x‑match: STILTS first; if it balks, Astropy fallback finishes the job.
- PS1 x‑match never skipped: CLI recognizes `raMean/decMean` and `RAMean/DecMean`.

**New env knobs**
```bash
# Fast PS1 for dev runs (0.5 arcmin radius)
export VASCO_PS1_RADIUS_DEG=0.00833333
export VASCO_PS1_TIMEOUT=12
export VASCO_PS1_ATTEMPTS=2
# Optional: disable PS1 entirely while iterating
# export VASCO_DISABLE_PS1=1
